### PR TITLE
refactor: Use HTTPS instead of axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "LordLucass"
   ],
   "dependencies": {
-    "axios": "^0.21.1",
     "events": "^3.3.0",
     "ws": "^8.0.0"
   },

--- a/src/client/ClientUtils.js
+++ b/src/client/ClientUtils.js
@@ -78,6 +78,17 @@ class ClientUtils {
       });
 
       if (options.data) request.end(JSON.stringify(options.data));
+
+      const timeout = this.#client.rest.options.timeout;
+
+      request.setTimeout(timeout, () => {
+        request.destroy(new Error(`
+          Request timed out. More than ${timeout}ms has been passed since the start of the request. 
+          
+          Method: ${options.method}
+          Route: ${options.path}
+        `));
+      });
     });
   }
 

--- a/src/client/ClientUtils.js
+++ b/src/client/ClientUtils.js
@@ -1,3 +1,5 @@
+const https = require("https");
+
 const Constants = require("../utils/Constants");
 const Guild = require("../structures/Guild");
 const User = require("../structures/User");
@@ -22,7 +24,7 @@ class ClientUtils {
 
     if (!guildId) return null;
 
-    return this.#client.guilds.get(guildId).channels.get(channelId);
+    return this.#client.guilds.get(guildId)?.channels.get(channelId);
   }
 
   /**
@@ -59,6 +61,24 @@ class ClientUtils {
     }
 
     throw new Error("Invalid target");
+  }
+
+  request (options) {
+    let data = "";
+
+    return new Promise((resolve, reject) => {
+      const request = https.request(options);
+
+      request.on("response", (resp) => {
+        resp.on("data", (str) => data += str);
+        resp.on("error", reject);
+        resp.on("end", () => {
+          return resolve({ data: JSON.parse(data), headers: resp.headers, code: resp.statusCode });
+        });
+      });
+
+      if (options.data) request.end(JSON.stringify(options.data));
+    });
   }
 
   /**

--- a/src/rest/Bucket.js
+++ b/src/rest/Bucket.js
@@ -113,7 +113,8 @@ class Bucket {
       await this.manager.client.utils.delay(timeout);
     }
 
-    const result = await this.manager.client.utils.request({ path, ...options });
+    const result = await this.manager.client.utils.request({ path, ...options })
+      .catch(error => error);
 
     const serverDate = result.headers.date;
     const remaining = result.headers["x-ratelimit-remaining"];

--- a/src/rest/RestManager.js
+++ b/src/rest/RestManager.js
@@ -17,7 +17,8 @@ class RestManager {
   constructor (client, options = {}) {
     this.options = Object.assign({
       version: Constants.REST.API_VERSION,
-      fetchAllUsers: false
+      fetchAllUsers: false,
+      timeout: 15000
     }, options.rest);
 
     /**

--- a/src/rest/RestManager.js
+++ b/src/rest/RestManager.js
@@ -90,7 +90,7 @@ class RestManager {
   }
 
   /**
-   * Formats the request data to a usable format for axios
+   * Formats the request data to a usable format for https
    * @param request The request data
    */
   #resolveRequest (url, method, options) {
@@ -106,7 +106,12 @@ class RestManager {
 
     const formattedUrl = `${this.apiURL}/${url.replace(/[/]?(\w+)/, "$1")}`;
 
-    const requestOptions = { data: options.data, method: method.toLowerCase(), headers };
+    const requestOptions = {
+      hostname: "discord.com",
+      data: options.data,
+      method,
+      headers
+    };
 
     return { formattedUrl, requestOptions };
   }

--- a/src/rest/RestManager.js
+++ b/src/rest/RestManager.js
@@ -45,7 +45,7 @@ class RestManager {
      * API Url to be used on requests.
      * @type {string}
      */
-    this.apiURL = `${Constants.REST.BASE_URL}/v${this.options.version}`;
+    this.apiURL = `/api/v${this.options.version}`;
 
     this.#deleteEmptyBuckets();
   }

--- a/src/structures/Member.js
+++ b/src/structures/Member.js
@@ -62,7 +62,7 @@ class Member extends Base {
    * @readonly
    */
   get user () {
-    return this.client.users.get(this.id);
+    return this.client.users.get(this.id); // Provavelmente adicionar inves de pegar? Assim caso nao exista, adicionar
   }
 
   /**

--- a/src/utils/Option.js
+++ b/src/utils/Option.js
@@ -37,7 +37,8 @@ module.exports = class Option {
       },
       rest: {
         version: Constants.REST.API_VERSION,
-        fetchAllUsers: false
+        fetchAllUsers: false,
+        timeout: 15000
       },
       defaultFormat: "png",
       defaultSize: 2048,

--- a/yarn.lock
+++ b/yarn.lock
@@ -226,13 +226,6 @@ at-least-node@^1.0.0:
   resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
   integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
-axios@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
-  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
-  dependencies:
-    follow-redirects "^1.10.0"
-
 babel-eslint@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
@@ -679,11 +672,6 @@ flatted@^3.1.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
-
-follow-redirects@^1.10.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
-  integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==
 
 fs-extra@^9.1.0:
   version "9.1.0"


### PR DESCRIPTION
Changes in order to support the native `https` module instead of `axios`